### PR TITLE
fix build error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,12 @@
+Prereq:
+* VSCode with WPILib extension 2022
+* CTRE-Pheonix library is installed locally
+
+Import into WPIlib 2022.
+
+
+Right click build.gradle-> manage vendor libraries -> install new libraries (offline)-> check CTRE-Pheonix
+
+Verify if the CTRE-Pheonix is in the "current libraries"
+
+Rebuild the project.

--- a/src/main/java/frc/robot/auto/TrajectoryFollowerCommand.java
+++ b/src/main/java/frc/robot/auto/TrajectoryFollowerCommand.java
@@ -177,7 +177,7 @@ public class TrajectoryFollowerCommand extends CommandBase {
         m_controller.calculate(m_pose.get(), desiredState, desiredState.poseMeters.getRotation(), desiredHeading);
     var targetWheelSpeeds = m_kinematics.toWheelSpeeds(targetChassisSpeeds);
 
-    targetWheelSpeeds.normalize(m_maxWheelVelocityMetersPerSecond);
+    targetWheelSpeeds.desaturate(m_maxWheelVelocityMetersPerSecond);
 
     var frontLeftSpeedSetpoint = targetWheelSpeeds.frontLeftMetersPerSecond;
     var rearLeftSpeedSetpoint = targetWheelSpeeds.rearLeftMetersPerSecond;


### PR DESCRIPTION
https://docs.wpilib.org/en/stable/docs/yearly-overview/yearly-changelog.html

normalize has been renamed to desaturate. Fix it.

Import this project to 2022 extension, add CTRE-Pheonix library, then rebuild the project.